### PR TITLE
Set Up GraphQL Codegen for Resolver Types"

### DIFF
--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -1,4 +1,4 @@
 # prisma
-prisma/dev.db
-prisma/dev.db-journal
+prisma/**/dev.db
+prisma/**/dev.db-journal
 

--- a/apps/server/biome.json
+++ b/apps/server/biome.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../../biome.json"],
+  "files": {
+    "include": ["src/**/*.ts"],
+    "ignore": ["src/types.ts"]
+  }
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
     "start": "npm run compile && node ./dist/index.js",
     "dev": "node --import ./scripts/register.js --watch src/index.ts",
     "lint": "biome check --write --unsafe --no-errors-on-unmatched ./src",
-    "codegen": "graphql-codegen",
+    "codegen": "graphql-codegen --config codegen.ts",
     "prisma": "prisma"
   },
   "dependencies": {

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -1,0 +1,117 @@
+import { GraphQLResolveInfo } from "graphql";
+import { DataSourceContext } from "./context";
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+};
+
+export type Query = {
+  __typename?: "Query";
+  hello?: Maybe<Scalars["String"]["output"]>;
+};
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Boolean: ResolverTypeWrapper<Scalars["Boolean"]["output"]>;
+  Query: ResolverTypeWrapper<{}>;
+  String: ResolverTypeWrapper<Scalars["String"]["output"]>;
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Boolean: Scalars["Boolean"]["output"];
+  Query: {};
+  String: Scalars["String"]["output"];
+};
+
+export type QueryResolvers<
+  ContextType = DataSourceContext,
+  ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"],
+> = {
+  hello?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+};
+
+export type Resolvers<ContextType = DataSourceContext> = {
+  Query?: QueryResolvers<ContextType>;
+};

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,7 @@
     "lineWidth": 130
   },
   "linter": {
+    "ignore": ["./apps/server/src/types.ts"],
     "enabled": true,
     "rules": {
       "recommended": true,


### PR DESCRIPTION
This pull request includes several changes to the server configuration and TypeScript types, as well as updates to the package scripts and `.gitignore` file. The most important changes are summarized below:

### Configuration Updates:
* [`apps/server/biome.json`](diffhunk://#diff-1f9cb96a9f943c51ef5f602ff4eb2e695ebc1d56d708ce45d1a856f7ca43c90cR1-R7): Added a new configuration file extending the base `biome.json` and specifying included and ignored files for the server app.
* [`biome.json`](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55R8): Updated the main configuration to ignore the `types.ts` file in the server app for linting.

### TypeScript Types:
* [`apps/server/src/types.ts`](diffhunk://#diff-df69a8eee2e8530ab6b2d9eebe27806a821850ecd9eaa9dee7aa1b541f0aa04cR1-R117): Added extensive TypeScript type definitions for GraphQL resolvers, including types for scalars, queries, resolvers, subscriptions, and directives.

### Package Scripts:
* [`apps/server/package.json`](diffhunk://#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2L11-R11): Modified the `codegen` script to use a specific configuration file (`codegen.ts`).

### Gitignore Update:
* [`apps/server/.gitignore`](diffhunk://#diff-73a249eca23b4a6165a70cd4d1534c5b9e65e734faad0b578b2288938ae623abL2-R3): Updated the `.gitignore` file to ignore all `dev.db` files within the `prisma` directory and its subdirectories.