### PR TITLE
Define Prisma Schema with Enhanced Models

### DIFF
--- a/apps/server/prisma/migrations/20250320163950_add_user_model/migration.sql
+++ b/apps/server/prisma/migrations/20250320163950_add_user_model/migration.sql
@@ -1,9 +1,0 @@
--- CreateTable
-CREATE TABLE "User" (
-    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    "email" TEXT NOT NULL,
-    "name" TEXT
-);
-
--- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/apps/server/prisma/migrations/20250323181712_define_social_network_models/migration.sql
+++ b/apps/server/prisma/migrations/20250323181712_define_social_network_models/migration.sql
@@ -1,0 +1,48 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "password" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Article" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Article_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Comment" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "content" TEXT NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "articleId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Comment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Comment_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Like" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "articleId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Like_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Like_userId_articleId_key" ON "Like"("userId", "articleId");

--- a/apps/server/prisma/migrations/20250323183943_social_network_models/migration.sql
+++ b/apps/server/prisma/migrations/20250323183943_social_network_models/migration.sql
@@ -1,0 +1,46 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Article" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Article_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Article" ("authorId", "content", "createdAt", "id", "title", "updatedAt") SELECT "authorId", "content", "createdAt", "id", "title", "updatedAt" FROM "Article";
+DROP TABLE "Article";
+ALTER TABLE "new_Article" RENAME TO "Article";
+CREATE INDEX "Article_title_idx" ON "Article"("title");
+CREATE TABLE "new_Comment" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "content" TEXT NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "articleId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Comment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Comment_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Comment" ("articleId", "authorId", "content", "createdAt", "id", "updatedAt") SELECT "articleId", "authorId", "content", "createdAt", "id", "updatedAt" FROM "Comment";
+DROP TABLE "Comment";
+ALTER TABLE "new_Comment" RENAME TO "Comment";
+CREATE TABLE "new_Like" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "articleId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Like_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Like" ("articleId", "createdAt", "id", "userId") SELECT "articleId", "createdAt", "id", "userId" FROM "Like";
+DROP TABLE "Like";
+ALTER TABLE "new_Like" RENAME TO "Like";
+CREATE UNIQUE INDEX "Like_userId_articleId_key" ON "Like"("userId", "articleId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "User_name_idx" ON "User"("name");

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -8,7 +8,50 @@ datasource db {
 }
 
 model User {
-  id    Int     @id @default(autoincrement())
-  email String  @unique
-  name  String?
+  id        Int       @id @default(autoincrement())
+  email     String    @unique
+  name      String?
+  password  String    // Will be hashed with bcrypt
+  articles  Article[] @relation(name: "UserArticles")
+  comments  Comment[] @relation(name: "UserComments")
+  likes     Like[]    @relation(name: "UserLikes")
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([name]) // Index for potential name searches
+}
+
+model Article {
+  id        Int       @id @default(autoincrement())
+  title     String
+  content   String
+  author    User      @relation(fields: [authorId], references: [id], name: "UserArticles", onDelete: Cascade)
+  authorId  Int
+  comments  Comment[] @relation(name: "ArticleComments")
+  likes     Like[]    @relation(name: "ArticleLikes")
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([title]) // Index for title searches
+}
+
+model Comment {
+  id        Int       @id @default(autoincrement())
+  content   String
+  author    User      @relation(fields: [authorId], references: [id], name: "UserComments", onDelete: Cascade)
+  authorId  Int
+  article   Article   @relation(fields: [articleId], references: [id], name: "ArticleComments", onDelete: Cascade)
+  articleId Int
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model Like {
+  id        Int       @id @default(autoincrement())
+  user      User      @relation(fields: [userId], references: [id], name: "UserLikes", onDelete: Cascade)
+  userId    Int
+  article   Article   @relation(fields: [articleId], references: [id], name: "ArticleLikes", onDelete: Cascade)
+  articleId Int
+  createdAt DateTime  @default(now())
+  @@unique([userId, articleId]) // Prevents duplicate likes
 }

--- a/apps/server/src/resolvers.ts
+++ b/apps/server/src/resolvers.ts
@@ -1,8 +1,14 @@
-export const resolvers = {
+import type { DataSourceContext } from "./context";
+import type { Resolvers } from "./types"; // Import generated types
+
+export const resolvers: Resolvers = {
   Query: {
     hello: async () => {
       await new Promise((resolve) => setTimeout(resolve, 5000));
       return "Hello, GraphQL!";
+    },
+    users: async (_parent, _args, context: DataSourceContext) => {
+      return context.dataSources.db.user.findMany();
     },
   },
 };

--- a/apps/server/src/schema.ts
+++ b/apps/server/src/schema.ts
@@ -1,5 +1,11 @@
 export const typeDefs = `#graphql
+  type User {
+    id: Int!
+    email: String!
+    name: String
+  }
   type Query {
     hello: String
+    users: [User!]!
   }
 `;

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -19,6 +19,14 @@ export type Scalars = {
 export type Query = {
   __typename?: "Query";
   hello?: Maybe<Scalars["String"]["output"]>;
+  users: Array<User>;
+};
+
+export type User = {
+  __typename?: "User";
+  email: Scalars["String"]["output"];
+  id: Scalars["Int"]["output"];
+  name?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -94,15 +102,19 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Boolean: ResolverTypeWrapper<Scalars["Boolean"]["output"]>;
+  Int: ResolverTypeWrapper<Scalars["Int"]["output"]>;
   Query: ResolverTypeWrapper<{}>;
   String: ResolverTypeWrapper<Scalars["String"]["output"]>;
+  User: ResolverTypeWrapper<User>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Boolean: Scalars["Boolean"]["output"];
+  Int: Scalars["Int"]["output"];
   Query: {};
   String: Scalars["String"]["output"];
+  User: User;
 };
 
 export type QueryResolvers<
@@ -110,8 +122,20 @@ export type QueryResolvers<
   ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"],
 > = {
   hello?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  users?: Resolver<Array<ResolversTypes["User"]>, ParentType, ContextType>;
+};
+
+export type UserResolvers<
+  ContextType = DataSourceContext,
+  ParentType extends ResolversParentTypes["User"] = ResolversParentTypes["User"],
+> = {
+  email?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = DataSourceContext> = {
   Query?: QueryResolvers<ContextType>;
+  User?: UserResolvers<ContextType>;
 };


### PR DESCRIPTION
This pull request involves significant changes to the database schema and the GraphQL API. The most important changes include the addition of new models for `User`, `Article`, `Comment`, and `Like`, updates to the GraphQL schema and resolvers, and the creation of new migrations to support these changes.

### Database Schema Changes:
* Added new models for `User`, `Article`, `Comment`, and `Like` in `migration.sql` files. These models include fields for relationships and timestamps.
* Redefined the `Article`, `Comment`, and `Like` tables to include cascading delete rules and added indexes for optimization.

### GraphQL Schema and Resolvers:
* Updated the GraphQL schema to include new types and queries for `User` and `users`. [[1]](diffhunk://#diff-ca76cab8bd94b74775374ab503f17e1b9e8d9c276f273ff77cf49ddca5ce3b54R2-R9) [[2]](diffhunk://#diff-df69a8eee2e8530ab6b2d9eebe27806a821850ecd9eaa9dee7aa1b541f0aa04cR22-R29) [[3]](diffhunk://#diff-df69a8eee2e8530ab6b2d9eebe27806a821850ecd9eaa9dee7aa1b541f0aa04cR105-R140)
* Modified the GraphQL resolvers to handle the new `users` query, fetching data from the database.

### Prisma Schema:
* Enhanced the `User` model with additional fields and relationships to `Article`, `Comment`, and `Like` models. Added new models for `Article`, `Comment`, and `Like` with appropriate relationships and indexes.

These changes collectively enhance the functionality of the application by introducing new entities and relationships, improving data integrity with cascading rules, and optimizing queries with indexes.