### PR TITLE
Fix utils module type

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@repo/utils",
+  "type": "module",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
This pull request includes a minor change to the `packages/utils/package.json` file. The change specifies that the package should be treated as a module by adding a `"type": "module"` entry.

* [`packages/utils/package.json`](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053R3): Added `"type": "module"` to specify the package should be treated as a module.