### PR TITLE
feat: ajout des mutations updateComment et deleteComment au schéma Gr…

### DIFF
--- a/apps/server/src/resolvers.ts
+++ b/apps/server/src/resolvers.ts
@@ -313,6 +313,25 @@ export const resolvers: Resolvers = {
       };
     },
 
+    deleteComment: async (_parent, { id }: { id: number }, context: DataSourceContext) => {
+      await simulateDelay();
+
+      if (!context.user) {
+        throw new Error("Unauthorized: Please log in");
+      }
+      const comment = await context.dataSources.db.comment.findUnique({
+        where: { id },
+      });
+      if (!comment) {
+        throw new Error("Comment not found");
+      }
+      if (comment.authorId !== context.user.id) {
+        throw new Error("Forbidden: You can only delete your own comments");
+      }
+      await context.dataSources.db.comment.delete({ where: { id } });
+      return true;
+    },
+
     register: async (_parent, args, context: DataSourceContext) => {
       // Simulate a delay for demonstration purposes
       await simulateDelay();

--- a/apps/server/src/resolvers.ts
+++ b/apps/server/src/resolvers.ts
@@ -259,6 +259,7 @@ export const resolvers: Resolvers = {
         },
         include: {
           author: true,
+          article: true,
         },
       });
 
@@ -270,6 +271,44 @@ export const resolvers: Resolvers = {
           ...comment.author,
           createdAt: comment.author.createdAt.toISOString(),
           updatedAt: comment.author.updatedAt.toISOString(),
+        },
+      };
+    },
+
+    updateComment: async (_parent, { id, content }: { id: number; content: string }, context: DataSourceContext) => {
+      await simulateDelay();
+
+      if (!context.user) {
+        throw new Error("Unauthorized: Please log in");
+      }
+      const comment = await context.dataSources.db.comment.findUnique({
+        where: { id },
+        include: { author: true },
+      });
+      if (!comment) {
+        throw new Error("Comment not found");
+      }
+      if (comment.authorId !== context.user.id) {
+        throw new Error("Forbidden: You can only update your own comments");
+      }
+      const updatedComment = await context.dataSources.db.comment.update({
+        where: { id },
+        data: { content },
+        include: { author: true, article: true },
+      });
+      return {
+        ...updatedComment,
+        createdAt: updatedComment.createdAt.toISOString(),
+        updatedAt: updatedComment.updatedAt.toISOString(),
+        author: {
+          ...updatedComment.author,
+          createdAt: updatedComment.author.createdAt.toISOString(),
+          updatedAt: updatedComment.author.updatedAt.toISOString(),
+        },
+        article: {
+          ...updatedComment.article,
+          createdAt: updatedComment.article.createdAt.toISOString(),
+          updatedAt: updatedComment.article.updatedAt.toISOString(),
         },
       };
     },

--- a/apps/server/src/schema.ts
+++ b/apps/server/src/schema.ts
@@ -48,5 +48,7 @@ export const typeDefs = `#graphql
     register(email: String!, password: String!, name: String!): AuthPayload!
     login(email: String!, password: String!): AuthPayload!
     createComment(content: String!, articleId: Int!): Comment!
+    updateComment(id: Int!, content: String!): Comment!
+    deleteComment(id: Int!): Boolean!
   }
 `;


### PR DESCRIPTION
This pull request introduces several updates to the GraphQL resolvers and schema in the `apps/server` module. The most significant changes include the addition of new comment management functionalities and the inclusion of related article data in query results.

### Comment Management Enhancements:

* Added a new resolver function `updateComment` to allow users to update their comments. This includes authorization checks and proper error handling for unauthorized access and non-existent comments. (`apps/server/src/resolvers.ts`)
* Updated the GraphQL schema to include `updateComment` and `deleteComment` mutations, enabling clients to update and delete comments. (`apps/server/src/schema.ts`)

### Data Inclusion Improvements:

* Modified the `include` parameter in the comment query to include related `article` data, ensuring that the article information is returned along with the comment details. (`apps/server/src/resolvers.ts`)