### PR TITLE
Ajout des détails des commentaires dans la page des articles

### DIFF
--- a/apps/web/src/components/comment.tsx
+++ b/apps/web/src/components/comment.tsx
@@ -1,0 +1,48 @@
+import { graphql } from "@/gql";
+import type { GetCommentQuery } from "@/gql/graphql";
+import { useSuspenseQuery } from "@apollo/client";
+
+const GET_COMMENT = graphql(`
+  query GetComment($id: Int!) {
+    article(id: $id) {
+      comments {
+        id
+        content
+        updatedAt
+        author {
+          id
+          name
+        }
+      }
+    }
+  }
+`);
+
+export default function CommentDetails({ id }: { id: number }) {
+  const { data } = useSuspenseQuery<GetCommentQuery>(GET_COMMENT, {
+    variables: {
+      id,
+    },
+  });
+  const comments = data?.article?.comments ?? [];
+  if (comments.length > 0) {
+    return (
+      <div className="flex flex-col gap-4">
+        {comments.map((comment) => (
+          <div key={comment.id} className="flex flex-col gap-2 border-gray-200 border-b-2 pb-4">
+            <div className="font-semibold text-sm">{comment.author.name}</div>
+            <div className="text-gray-700 text-sm">{comment.content}</div>
+            <div className="text-gray-500 text-xs">
+              {new Date(comment.updatedAt).toLocaleDateString("fr-FR", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return <div> Pas de commentaire actuellement ! </div>;
+}

--- a/apps/web/src/screens/articles/[id]/page.tsx
+++ b/apps/web/src/screens/articles/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Comment from "@/components/comment";
 import { Skeleton } from "@/components/skeleton";
 import { graphql } from "@/gql";
 import type { GetArticleQuery } from "@/gql/graphql";
@@ -39,6 +40,13 @@ export default function ArticleDetailsPage(props: { params?: { id: string } }) {
         <Suspense fallback={<ArticleDetailsFallback />}>
           <ArticleDetails id={+id} navigate={navigate} />
         </Suspense>
+        <CardBody>
+          <p className="font-semibold">Comments</p>
+
+          <Suspense fallback={<Skeleton className="h-6 w-full" />}>
+            <Comment id={+id} />
+          </Suspense>
+        </CardBody>
       </Card>
     </div>
   );


### PR DESCRIPTION
This pull request introduces a new feature to display comments for articles on the article details page. The changes involve adding a new `CommentDetails` component and integrating it into the article details page.

### New Feature: Display Comments for Articles

* [`apps/web/src/components/comment.tsx`](diffhunk://#diff-48135f0c6b7d4133961b76ba58b71b4612bbb0b855f2320f99a0c0651b8fc227R1-R48): Added a new `CommentDetails` component that fetches and displays comments for a given article using a GraphQL query.
* `apps/web/src/screens/articles/[id]/page.tsx`: Imported the new `CommentDetails` component and integrated it into the `ArticleDetailsPage` component to display comments below the article details. ([apps/web/src/screens/articles/[id]/page.tsxR1](diffhunk://#diff-690ced87d8c103dd2cd7a730512250ab378fbc8dada413202c62028ce1a703adR1), [apps/web/src/screens/articles/[id]/page.tsxR43-R49](diffhunk://#diff-690ced87d8c103dd2cd7a730512250ab378fbc8dada413202c62028ce1a703adR43-R49))